### PR TITLE
Adds details to assertion in PyTorch test

### DIFF
--- a/integrations/pytorch/Neptune-PyTorch.ipynb
+++ b/integrations/pytorch/Neptune-PyTorch.ipynb
@@ -353,8 +353,7 @@
     "## check logs\n",
     "correct_logs = ['batch_loss']\n",
     "\n",
-    "if set(all_logs.keys()) != set(correct_logs):\n",
-    "    raise ValueError('incorrect metrics')"
+    "assert set(all_logs.keys()) == set(correct_logs), 'Expected: {}. Actual: {}'.format(set(correct_logs), set(all_logs.keys()))"
    ]
   },
   {
@@ -604,8 +603,7 @@
     "## check logs\n",
     "correct_logs = ['batch_loss', 'predictions']\n",
     "\n",
-    "if set(all_logs.keys()) != set(correct_logs):\n",
-    "    raise ValueError('incorrect metrics')"
+    "assert set(all_logs.keys()) == set(correct_logs), 'Expected: {}. Actual: {}'.format(set(correct_logs), set(all_logs.keys()))"
    ]
   },
   {

--- a/integrations/pytorch/tests/Neptune-PyTorch.py
+++ b/integrations/pytorch/tests/Neptune-PyTorch.py
@@ -85,8 +85,7 @@ all_logs = exp.get_logs()
 ## check logs
 correct_logs = ['batch_loss']
 
-if set(all_logs.keys()) != set(correct_logs):
-    raise ValueError('incorrect metrics')
+assert set(all_logs.keys()) == set(correct_logs), 'Expected: {}. Actual: {}'.format(set(correct_logs), set(all_logs.keys()))
 
 neptune.stop()
 
@@ -150,8 +149,7 @@ all_logs = exp.get_logs()
 ## check logs
 correct_logs = ['batch_loss', 'predictions']
 
-if set(all_logs.keys()) != set(correct_logs):
-    raise ValueError('incorrect metrics')
+assert set(all_logs.keys()) == set(correct_logs), 'Expected: {}. Actual: {}'.format(set(correct_logs), set(all_logs.keys()))
 
 ## Stop logging
 

--- a/integrations/pytorch/tests/Neptune-PyTorch_upgraded_libs.py
+++ b/integrations/pytorch/tests/Neptune-PyTorch_upgraded_libs.py
@@ -87,8 +87,7 @@ all_logs = exp.get_logs()
 ## check logs
 correct_logs = ['batch_loss']
 
-if set(all_logs.keys()) != set(correct_logs):
-    raise ValueError('incorrect metrics')
+assert set(all_logs.keys()) == set(correct_logs), 'Expected: {}. Actual: {}'.format(set(correct_logs), set(all_logs.keys()))
 
 neptune.stop()
 
@@ -154,8 +153,7 @@ all_logs = exp.get_logs()
 ## check logs
 correct_logs = ['batch_loss', 'predictions']
 
-if set(all_logs.keys()) != set(correct_logs):
-    raise ValueError('incorrect metrics')
+assert set(all_logs.keys()) == set(correct_logs), 'Expected: {}. Actual: {}'.format(set(correct_logs), set(all_logs.keys()))
 
 ## Stop logging
 


### PR DESCRIPTION
This might help with debugging failing tests, especially:

```
ValueError                                Traceback (most recent call last)
~/work/neptune-examples/neptune-examples/integrations/pytorch-lightning/tests/Neptune-PyTorch-Lightning-basic_upgraded_libs.py in <module>
     88 
     89 if set(neptune_logger.experiment.get_logs().keys()) != set(correct_logs):
---> 90     raise ValueError('incorrect metrics')
ValueError: incorrect metrics
```